### PR TITLE
fix incorrect map path

### DIFF
--- a/pmb2_2dnav/launch/pmb2_nav_bringup.launch.py
+++ b/pmb2_2dnav/launch/pmb2_nav_bringup.launch.py
@@ -73,7 +73,7 @@ def navigation_bringup(context, *args, **kwargs):
                 ),
                 "map": os.path.join(
                     pal_maps,
-                    "configurations",
+                    "maps",
                     world_name,
                     "map.yaml",
                 ),


### PR DESCRIPTION
Pal maps appear to be at `/opt/ros/humble/share/pal_maps/maps/` and not `/opt/ros/humble/share/pal_maps/configurations`. This change fixes that. 

```
$ ls /opt/ros/humble/share/pal_maps/maps/
namo  pal_office_4th_floor  pal_office_7th_floor  small_house  small_office  small_warehouse
```